### PR TITLE
Fixed 'Class PublicKey is implemented both'

### DIFF
--- a/Source/SwiftyRSA+ObjC.swift
+++ b/Source/SwiftyRSA+ObjC.swift
@@ -49,7 +49,7 @@ public class _objc_SwiftyRSA: NSObject { // swiftlint:disable:this type_name
 
 // MARK: - PublicKey
 
-@objc(PublicKey)
+@objc(ObjcPublicKey)
 public class _objc_PublicKey: NSObject, Key, ObjcBridgeable { // swiftlint:disable:this type_name
     
     fileprivate let swiftValue: SwiftyRSA.PublicKey


### PR DESCRIPTION
objc[13181]: Class PublicKey is implemented in both /System/Library/PrivateFrameworks/MessageProtection.framework/MessageProtection (0x24e9dbcc0) and /private/var/containers/Bundle/Application/AA0EFB35-6414-4395-98E5-1F3AFD934168/Band.app/Frameworks/SwiftyRSA.framework/SwiftyRSA (0x10f18a1e0). One of the two will be used. Which one is undefined.